### PR TITLE
Improved flags and targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS =
 
 # Project files
 TARGET = free
-TARGET_TEST = $(TARGET)_test
+TARGET_TEST = $(TARGET) 	
 SRCS = free.c 
 OBJS = $(SRCS:.c=.o)
 OBJS_TEST = $(SRCS:.c=.o.test)
@@ -37,4 +37,4 @@ $(TARGET_TEST): $(OBJS_TEST)
 
 # Clean target
 clean:
-	rm -f $(OBJS) $(TARGET) $(OBJS_TEST) $(TARGET_TEST)
+	rm -f $(TARGET) $(OBJS) $(OBJS_TEST)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ brew install free-mac
   
 #### Compiling
 The project includes a Makefile for straightforward compilation. There are two targets:
-- `make release` for compiling the tool for production use.
+- `make` for compiling the tool for production use.
 - `make test` for compiling with AddressSanitizer for development and debugging.
 
 ##### Release Build
 ```bash
-make release
+make
 ```
 
 ##### Test Build


### PR DESCRIPTION
Refactor the Makefile to include more robust compiler flags for both release and test builds.